### PR TITLE
Fix inverted energy surplus logic

### DIFF
--- a/FVctl.py
+++ b/FVctl.py
@@ -299,10 +299,8 @@ def main():
     ha_max_charge_current = get_int_from_hass(ha_max_charge_current_entity) or 0
 
     max_battery_charge_power = ha_battery_voltage * ha_max_charge_current
-    if max_battery_charge_power > 0:
-        max_battery_charge_power = 0
-    else:
-        max_battery_charge_power = abs(max_battery_charge_power)
+    max_battery_charge_power = abs(max_battery_charge_power)
+    logger.debug(f"Max battery power = {max_battery_charge_power} W")
 
     if args.current_power is not None:
         logger.debug(f"Current value got from CLI")
@@ -329,7 +327,7 @@ def main():
     # timto by tedy melo zbyt energie na plny vykon do baterie a presto
     # jeste pripadne mozno zapnout bojler
     if current_power > max_battery_charge_power:
-        logger.info(f"Current power > max_battery_charge_power --> rerun of decide_distribution")
+        logger.info(f"Current power > max_battery_charge_power --> rerun of decide_distribution: %d < %d", current_power, max_battery_charge_power)
         current_power = current_power - max_battery_charge_power
         logger.info(f"New current_power = %d, rerun == True", current_power)
         current_power = decide_distribution(current_power, True)


### PR DESCRIPTION
Inverted logic of energy surplus - in case changed from max_battery_charge_power = -ENERGY_to_battery  to =voltage*max_charging_current, this value is EVERYTIME positive. The invertion does not work there, hence wrong logic was introduced. 
Also adding one more debug lines